### PR TITLE
Remove aggregate.sh - no longer used

### DIFF
--- a/javaduck-image/bin/aggregate.sh
+++ b/javaduck-image/bin/aggregate.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# mount efs volume 
-
-# run aggregator
-env
-java -jar /opt/aggregator/aggregation-worker-1.0-SNAPSHOT.jar $*
-exit $?
-


### PR DESCRIPTION
I keep having to look into the javaduck-image directory to see whats there - time to remove it as its no longer used.