### PR TITLE
Fixes #95 - up the amount of data copied at a time from 1KIB to 10MB.

### DIFF
--- a/integration-testing/src/test/java/au/org/emii/wps/it/ExecuteIT.java
+++ b/integration-testing/src/test/java/au/org/emii/wps/it/ExecuteIT.java
@@ -66,7 +66,7 @@ public class ExecuteIT {
             .body(hasXPath("/ExecuteResponse/Status/ProcessSucceeded"));
     }
 
-    @Test @Ignore // Runs indefinitely - TODO:Fix problem and enable test
+    @Test
     public void testSrsSubset() {
         Execute request = new ExecuteRequestBuilder()
             .identifer("gs:GoGoDuck")

--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -74,7 +74,7 @@ Parameters:
     Type: String
   chunkSize:
     Type: Number
-    Default: 1024
+    Default: 10000000
   workerDownloadAttempts:
     Type: Number
     Default: 4


### PR DESCRIPTION
Copying in 1K chunks takes a very long time for large datasets.