### PR TITLE
Fixed the custom domain name creation dependency

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -461,7 +461,6 @@ Resources:
   WpsApiGatewayStage:
     DependsOn:
       - WpsApiGatewayAccount
-      - WpsApiGatewayDeployment
       - WPSRestApi
     Type: AWS::ApiGateway::Stage
     Properties:
@@ -483,9 +482,13 @@ Resources:
   WpsDomainToAPIMapping:
     Type: 'AWS::ApiGateway::BasePathMapping'
     Condition: CreateWpsApiGatewayDomainName
+    DependsOn:
+    - WpsApiGatewayStage
+    - WpsRoute53RecordSet
     Properties:
       DomainName: !Ref WpsApiGatewayDomainName
       RestApiId: !Ref WPSRestApi
+      Stage: !Ref wpsApiStage
   WpsRoute53RecordSet:
     Type: 'AWS::Route53::RecordSet'
     Condition: CreateWpsApiGatewayDomainName


### PR DESCRIPTION
dev.properties 

```
requestHandlerCodeURL=https://s3-ap-southeast-2.amazonaws.com/wps-lambda/request-handler-0.01-lambda-package.zip
jobStatusCodeURL=https://s3-ap-southeast-2.amazonaws.com/wps-lambda/job-status-service-0.01-lambda-package.zip
dockerImage=615645230945.dkr.ecr.ap-southeast-2.amazonaws.com/javaduck:sandbox
geoserver=http://geoserver-123.aodn.org.au/geoserver/imos/ows
hostedZoneName=dev.aodn.org.au
wpsDomainName=**_YourCustomDomainName_**
acmCertificate=arn:aws:acm:us-east-1:615645230945:certificate/06e50848-29a7-47c3-8a3f-c3212b608a8d
```

Fix for https://github.com/aodn/aws-wps/issues/92