### PR TITLE
Fixes #120

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -82,6 +82,9 @@ Parameters:
   maxVCPUs:
     Type: Number
     Default: 4
+  maxHeapSize:
+    Type: String
+    Default: 512m
   geoserver:
     Type: String
     Description: Geoserver from which to source files to aggregate
@@ -326,6 +329,8 @@ Resources:
         Vcpus: !Ref jobVCPUs
         Memory: !Ref jobMemory
         JobRoleArn: !Ref JobInstanceRole
+        Command:
+          - !Join [ "", [ "-Xmx",  !Ref maxHeapSize] ]
         Environment:
           -
             Name: "OUTPUT_S3_FILENAME"


### PR DESCRIPTION
Set default max heap size to 512m.

Without specifying a value for max heap size, java uses 1/4 of the memory available on the instance it is running on as the default which results in the allowed memory for the job being exceeded on larger aggregations.

I was running on an r4.large instance which has 15.25GB memory, which meant java would have been using a max heap size of around 3.8Gb, but the job is limited to 2GB.