### PR TITLE
Fixes #125

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+services:
+  - docker
+  
+language: java
+
+jdk:
+    - openjdk8
+    - oraclejdk8

--- a/aggregation-worker/pom.xml
+++ b/aggregation-worker/pom.xml
@@ -91,6 +91,10 @@
 
     <repositories>
         <repository>
+            <id>aodn</id>
+            <url>http://content.aodn.org.au/repo/maven/</url>
+        </repository>
+        <repository>
             <id>unidata-releases</id>
             <name>UNIDATA Releases</name>
             <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/</url>
@@ -122,7 +126,7 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>initialize</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>

--- a/job-status-service/pom.xml
+++ b/job-status-service/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>au.org.emii</groupId>
     <artifactId>job-status-service</artifactId>
-    <version>0.01</version>
+    <version>0.0.2</version>
 
     <parent>
         <groupId>au.org.emii</groupId>
         <artifactId>aws-wps</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.01</version>
+        <version>0.0.2</version>
     </parent>
 
     <dependencies>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>au.org.emii</groupId>
             <artifactId>wps-common</artifactId>
-            <version>0.01</version>
+            <version>0.0.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Use s3 maven repository to source current version of dependent IMOS wars.

Copy dependencies in package phase so it doesn't prevent compilation/unit testing on clean build

Ensure it compiles and unit tests pass with travis.