### PR TITLE
Use unique timestamp when adding snapshot dependencies as per manifest

### DIFF
--- a/aggregation-worker/pom.xml
+++ b/aggregation-worker/pom.xml
@@ -132,6 +132,7 @@
                         </goals>
                         <configuration>
                             <overWriteReleases>false</overWriteReleases>
+                            <useBaseVersion>false</useBaseVersion>
                             <includeScope>runtime</includeScope>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>


### PR DESCRIPTION
Fixes issue finding NetcdfReader when running aggregation worker.