### PR TITLE
Add some content checks for aggregations and provenance documents

### DIFF
--- a/integration-testing/pom.xml
+++ b/integration-testing/pom.xml
@@ -63,6 +63,16 @@
             <artifactId>commons-csv</artifactId>
             <version>1.4</version>
         </dependency>
+        <dependency>
+            <groupId>edu.ucar</groupId>
+            <artifactId>cdm</artifactId>
+            <version>4.6.9</version>
+        </dependency>
+        <dependency>
+            <groupId>edu.ucar</groupId>
+            <artifactId>httpservices</artifactId>
+            <version>4.6.9</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-testing/src/test/java/au/org/emii/wps/it/DescribeProcessIT.java
+++ b/integration-testing/src/test/java/au/org/emii/wps/it/DescribeProcessIT.java
@@ -57,7 +57,8 @@ public class DescribeProcessIT {
         .then()
             .statusCode(200)
             .contentType(ContentType.XML)
-            .body(validateWith("/wps/1.0.0/wpsAll.xsd"));
+            .body(validateWith("/wps/1.0.0/wpsAll.xsd"))
+            .body("ProcessDescriptions.ProcessDescription.Identifier", equalTo("gs:GoGoDuck"));
     }
 
 }

--- a/integration-testing/src/test/java/au/org/emii/wps/it/GetCapabilitiesIT.java
+++ b/integration-testing/src/test/java/au/org/emii/wps/it/GetCapabilitiesIT.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import static au.org.emii.wps.util.Matchers.validateWith;
 import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.hasItem;
 
 public class GetCapabilitiesIT {
     private static final String SERVICE_ENDPOINT = System.getenv("WPS_ENDPOINT");
@@ -36,6 +37,7 @@ public class GetCapabilitiesIT {
         .then()
             .statusCode(200)
             .contentType(ContentType.XML)
-            .body(validateWith("/wps/1.0.0/wpsAll.xsd"));
+            .body(validateWith("/wps/1.0.0/wpsAll.xsd"))
+            .body("Capabilities.ProcessOfferings.Process.Identifier", hasItem("gs:GoGoDuck"));
     }
 }

--- a/integration-testing/src/test/java/au/org/emii/wps/util/GPathMatcher.java
+++ b/integration-testing/src/test/java/au/org/emii/wps/util/GPathMatcher.java
@@ -1,0 +1,63 @@
+package au.org.emii.wps.util;
+
+import com.jayway.restassured.assertion.XMLAssertion;
+import groovy.util.XmlSlurper;
+import groovy.util.slurpersupport.GPathResult;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+
+public class GPathMatcher extends TypeSafeMatcher<String> {
+    private final String path;
+    private final Matcher valueMatcher;
+
+    public static GPathMatcher hasGPath(String path, Matcher matcher) {
+        return new GPathMatcher(path, matcher);
+    }
+
+    public GPathMatcher(String path, Matcher valueMatcher) {
+        this.path = path;
+        this.valueMatcher = valueMatcher;
+    }
+
+    @Override
+    protected boolean matchesSafely(String value) {
+        Object result = getGPathResult(value);
+
+        // Check for match
+        return valueMatcher.matches(result);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        valueMatcher.describeTo(description);
+        description.appendText(" at ").appendValue(path);
+    }
+
+    @Override
+    protected void describeMismatchSafely(String value, Description mismatchDescription) {
+        Object result = getGPathResult(value);
+        valueMatcher.describeMismatch(result, mismatchDescription);
+    }
+
+    private Object getGPathResult(String value) {
+        // Use xmlslurper to parse the value
+        GPathResult parser = null;
+
+        try {
+            parser = new XmlSlurper().parseText(value);
+        } catch (IOException |SAXException |ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Use RestAssured's XMLAssertion to get GPath result
+        XMLAssertion assertion = new XMLAssertion();
+        assertion.setKey(path);
+        return assertion.getResult(parser, null);
+    }
+
+}

--- a/integration-testing/src/test/java/au/org/emii/wps/util/NcmlValidatable.java
+++ b/integration-testing/src/test/java/au/org/emii/wps/util/NcmlValidatable.java
@@ -1,0 +1,70 @@
+package au.org.emii.wps.util;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.hamcrest.xml.HasXPath;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+import ucar.nc2.NCdumpW;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class NcmlValidatable {
+    private static final String XPATH = "XPath";
+    private final String ncml;
+
+    public static NcmlValidatable getNcml(String location) throws IOException {
+        StringWriter stringWriter = new StringWriter();
+        NCdumpW.print(location, stringWriter, false, false, true, false, null, null);
+        return new NcmlValidatable(stringWriter.toString());
+    }
+
+    public NcmlValidatable(String ncml) {
+        this.ncml = ncml;
+    }
+
+    public void content(Matcher... matchers) {
+        for (Matcher matcher: matchers) {
+            if (isXPathMatcher(matcher)) {
+                // Node matcher
+                Node node = getNode(ncml);
+                assertThat(node, matcher);
+            } else {
+                // String matcher
+                assertThat(ncml, matcher);
+            }
+        }
+    }
+
+    private boolean isXPathMatcher(Matcher matcher) {
+        return matcher instanceof HasXPath || isNestedMatcherContainingXPathMatcher(matcher);
+    }
+
+    private boolean isNestedMatcherContainingXPathMatcher(Matcher matcher) {
+        Description description = new StringDescription();
+        matcher.describeTo(description);
+        return description.toString().contains(XPATH);
+    }
+
+    private Node getNode(String value) {
+        // Use XPath Matching
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+        Node node;
+
+        try {
+            node = factory.newDocumentBuilder().parse(new ByteArrayInputStream(value.getBytes())).getDocumentElement();
+        } catch (SAXException |IOException |ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+        return node;
+    }
+
+}


### PR DESCRIPTION
to ensure config is being applied as required

Note provenance and timeseries checks are currently failing due to #144 and #143

Requires #141 for other aggregation tests to work.