### PR TITLE
Update compute environment version to force replacement

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -443,7 +443,7 @@ Resources:
     DeletionPolicy: Delete
     Properties:
       Type: MANAGED
-      ComputeEnvironmentName: !Sub 'JavaDuckSpotComputeEnvironment-${customAmiId}-${AWS::StackName}'
+      ComputeEnvironmentName: !Sub 'JavaDuckSpotComputeEnvironment-v1-${AWS::StackName}'
       ComputeResources:
         Type: SPOT
         MinvCpus: 0


### PR DESCRIPTION
Switch to using a version number to force replacement of the compute environment.  Most compute environment details cannot be modified (ami id, instance types, max spot price) and need a name change to force a replacement.