### PR TITLE
Use a version number in compute environment name to trigger replacement

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -443,7 +443,7 @@ Resources:
     DeletionPolicy: Delete
     Properties:
       Type: MANAGED
-      ComputeEnvironmentName: !Sub 'JavaDuckSpotComputeEnvironment-${customAmiId}-${AWS::StackName}'
+      ComputeEnvironmentName: !Sub 'JavaDuckSpotComputeEnvironment-v1-${AWS::StackName}'
       ComputeResources:
         Type: SPOT
         MinvCpus: 0


### PR DESCRIPTION
Need to change the version (name) whenever an unmodifiable setting
(instance type, ami, max spot price etc)  is changed to force
the compute environment to be replaced otherwise the stack update fails
because it can't update the existing compute environment.

Looked at including the template version number, but that would trigger the
compute environment to be replaced every deployment which would create
unnecessary dependencies on running jobs. 