### PR TITLE
Place logo url directly in templates rather than promulgating through stack

### DIFF
--- a/dev.properties
+++ b/dev.properties
@@ -5,4 +5,3 @@ s3LambdaCodeURL=https://s3-ap-southeast-2.amazonaws.com/wps-lambda/request-handl
 templatesURL=https://raw.githubusercontent.com/aodn/aws-wps/master/wps-common/src/main/resources/config/templates.xml
 bootstrapCssURL=https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css
 aodnCssURL=https://raw.githubusercontent.com/aodn/aodn-portal/master/web-app/css/AODNTheme.css
-aodnLogoURL=https://raw.githubusercontent.com/aodn/aodn-portal/master/web-app/images/AODN/AODN_logo_fullText.png

--- a/job-status-service/src/main/java/au/org/aodn/aws/wps/lambda/JobStatusServiceRequestHandler.java
+++ b/job-status-service/src/main/java/au/org/aodn/aws/wps/lambda/JobStatusServiceRequestHandler.java
@@ -328,7 +328,6 @@ public class JobStatusServiceRequestHandler implements RequestHandler<JobStatusR
 
             statusFileTransformer.setParameter("bootstrapCssLocation", WpsConfig.getBootstrapCssS3ExternalURL());
             statusFileTransformer.setParameter("aodnCssLocation", WpsConfig.getAodnCssS3ExternalURL());
-            statusFileTransformer.setParameter("aodnLogoLocation", WpsConfig.getAodnLogoS3ExternalURL());
 
             // Source
             JAXBContext jc = JAXBContext.newInstance(ExecuteResponse.class);
@@ -444,7 +443,6 @@ public class JobStatusServiceRequestHandler implements RequestHandler<JobStatusR
 
             params.put("bootstrapCssLocation", WpsConfig.getBootstrapCssS3ExternalURL());
             params.put("aodnCssLocation", WpsConfig.getAodnCssS3ExternalURL());
-            params.put("aodnLogoLocation", WpsConfig.getAodnLogoS3ExternalURL());
             params.put("queueName", queueName);
             params.put("statusServiceBaseLink", WpsConfig.getBaseStatusServiceAdminLink());
 

--- a/job-status-service/src/main/resources/templates/job_queue_html_template.ftl
+++ b/job-status-service/src/main/resources/templates/job_queue_html_template.ftl
@@ -30,7 +30,7 @@
         <div class="portalheader">
             <div class="container">
                 <a class="btn" role="button" href="https://portal.aodn.org.au">
-                    <img src="${aodnLogoLocation}" alt="Portal logo"/>
+                    <img src="https://s3-ap-southeast-2.amazonaws.com/static.emii.org.au/images/logo/AODN_logo_fullText.png" alt="Portal logo"/>
                 </a>
             </div>
         </div>

--- a/job-status-service/src/main/resources/templates/job_queue_html_template.ftl
+++ b/job-status-service/src/main/resources/templates/job_queue_html_template.ftl
@@ -30,7 +30,7 @@
         <div class="portalheader">
             <div class="container">
                 <a class="btn" role="button" href="https://portal.aodn.org.au">
-                    <img src="https://s3-ap-southeast-2.amazonaws.com/static.emii.org.au/images/logo/AODN_logo_fullText.png" alt="Portal logo"/>
+                    <img src="https://static.emii.org.au/images/logo/AODN_logo_fullText.png" alt="Portal logo"/>
                 </a>
             </div>
         </div>

--- a/job-status-service/src/main/resources/templates/job_status_html_transform.xsl
+++ b/job-status-service/src/main/resources/templates/job_status_html_transform.xsl
@@ -35,7 +35,7 @@
         <div class="portalheader">
             <div class="container">
                 <a class="btn" role="button" href="https://portal.aodn.org.au">
-                    <img src="https://s3-ap-southeast-2.amazonaws.com/static.emii.org.au/images/logo/AODN_logo_fullText.png" alt="Portal logo"/>
+                    <img src="https://static.emii.org.au/images/logo/AODN_logo_fullText.png" alt="Portal logo"/>
                 </a>
             </div>
         </div>

--- a/job-status-service/src/main/resources/templates/job_status_html_transform.xsl
+++ b/job-status-service/src/main/resources/templates/job_status_html_transform.xsl
@@ -9,7 +9,6 @@
         <xsl:param name="submittedTime" />
         <xsl:param name="bootstrapCssLocation"/>
         <xsl:param name="aodnCssLocation"/>
-        <xsl:param name="aodnLogoLocation"/>
         <xsl:param name="requestXML"/>
         <xsl:param name="logFileLink"/>
 
@@ -36,7 +35,7 @@
         <div class="portalheader">
             <div class="container">
                 <a class="btn" role="button" href="https://portal.aodn.org.au">
-                    <img src="{$aodnLogoLocation}" alt="Portal logo"/>
+                    <img src="https://s3-ap-southeast-2.amazonaws.com/static.emii.org.au/images/logo/AODN_logo_fullText.png" alt="Portal logo"/>
                 </a>
             </div>
         </div>

--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -43,8 +43,6 @@ Parameters:
     Type: String
   aodnCssURL:
     Type: String
-  aodnLogoURL:
-    Type: String
   jobName:
     Type: String
     Default: javaduck
@@ -130,7 +128,6 @@ Mappings:
       templates: templates.xml
       bootstrapCss: bootstrap.min.css
       jobStatusCss: AODNStatusPage.css
-      aodnLogo: AODN_logo_fullText.png
   production:
     ap-southeast-2:
       vpc: vpc-7302ee16
@@ -685,7 +682,6 @@ Resources:
           CONFIG_S3_KEY: !Ref s3configKey
           BOOTSTRAP_CSS_FILENAME: !FindInMap [ConfigurationFileMap, Filename, bootstrapCss]
           AODN_CSS_FILENAME: !FindInMap [ConfigurationFileMap, Filename, jobStatusCss]
-          AODN_LOGO_FILENAME: !FindInMap [ConfigurationFileMap, Filename, aodnLogo]
           AWS_BATCH_JOB_QUEUE_NAME: !Ref JobQueue
           AWS_BATCH_LOG_GROUP_NAME: /aws/batch/job
           STATUS_SERVICE_ENDPOINT_URL: !If [
@@ -842,8 +838,6 @@ Resources:
           HTTP_FILE_SUMOLOGIC_LAMBDA_FILENAME: !Ref sumologicLambdaCodeFilename
           HTTP_FILE_BOOTSTRAP_CSS: !Ref bootstrapCssURL
           HTTP_FILE_BOOTSTRAP_CSS_FILENAME: !FindInMap [ConfigurationFileMap, Filename, bootstrapCss]
-          HTTP_FILE_AODN_LOGO: !Ref aodnLogoURL
-          HTTP_FILE_AODN_LOGO_FILENAME: !FindInMap [ConfigurationFileMap, Filename, aodnLogo]
   S3PutConfigurationFiles:
     Type: Custom::S3PutObject
     Properties:

--- a/wps-common/src/main/java/au/org/aodn/aws/wps/status/WpsConfig.java
+++ b/wps-common/src/main/java/au/org/aodn/aws/wps/status/WpsConfig.java
@@ -81,7 +81,6 @@ public class WpsConfig {
 
     private static final String BOOTSTRAP_CSS_FILENAME_CONFIG_KEY = "BOOTSTRAP_CSS_FILENAME";
     private static final String AODN_CSS_FILENAME_CONFIG_KEY = "AODN_CSS_FILENAME";
-    private static final String AODN_LOGO_FILENAME_CONFIG_KEY = "AODN_LOGO_FILENAME";
 
     public static final String LANGUAGE_KEY = "language";
 
@@ -140,7 +139,6 @@ public class WpsConfig {
 
             setProperty(properties, BOOTSTRAP_CSS_FILENAME_CONFIG_KEY);
             setProperty(properties, AODN_CSS_FILENAME_CONFIG_KEY);
-            setProperty(properties, AODN_LOGO_FILENAME_CONFIG_KEY);
             setProperty(properties, AWS_BATCH_CONFIG_S3_KEY);
             setProperty(properties, AWS_BATCH_LOG_GROUP_NAME_CONFIG_KEY);
         }
@@ -187,10 +185,6 @@ public class WpsConfig {
 
     public static String getAodnCssS3ExternalURL() {
         return getConfigFileS3ExternalURL(AODN_CSS_FILENAME_CONFIG_KEY);
-    }
-
-    public static String getAodnLogoS3ExternalURL() {
-        return getConfigFileS3ExternalURL(AODN_LOGO_FILENAME_CONFIG_KEY);
     }
 
     private static String getConfigFileS3ExternalURL(String filename) {


### PR DESCRIPTION
Alternative solution to https://github.com/aodn/aws-wps/pull/180. I think this is better because I'd expect a particular template to be tightly coupled to a particular logo. To change the logo a dev would just have to change the template to point to a different location.