### PR TITLE
Fix completed email link

### DIFF
--- a/aggregation-worker/src/main/java/au/org/emii/aggregationworker/AggregationRunner.java
+++ b/aggregation-worker/src/main/java/au/org/emii/aggregationworker/AggregationRunner.java
@@ -215,6 +215,9 @@ public class AggregationRunner implements CommandLineRunner {
                 String resultUrl = WpsConfig.getS3ExternalURL(outputBucketName,
                         outputFileManager.getJobFileKey(fullOutputFilename));
 
+                //  URL for the status page for this job
+                String statusUrl = WpsConfig.getStatusServiceHtmlEndpoint(batchJobId);
+
                 if (requestHelper.hasRequestedOutput("result")) {
                     outputMap.put("result", resultUrl);
                 }
@@ -269,7 +272,7 @@ public class AggregationRunner implements CommandLineRunner {
                 statusFileManager.write(statusDocument, statusFilename, STATUS_FILE_MIME_TYPE);
 
                 //  Send completed job email to user
-                emailService.sendCompletedJobEmail(contactEmail, batchJobId, resultUrl, S3Utils.getExpirationinDays(outputBucketName));
+                emailService.sendCompletedJobEmail(contactEmail, batchJobId, statusUrl, S3Utils.getExpirationinDays(outputBucketName));
 
             } finally {
                 if (jobDir != null) {

--- a/wps-common/src/main/java/au/org/aodn/aws/util/EmailService.java
+++ b/wps-common/src/main/java/au/org/aodn/aws/util/EmailService.java
@@ -84,10 +84,10 @@ public class EmailService {
         sendEmail(to, from, subject, null, textBody);
     }
 
-    public void sendCompletedJobEmail(String to, String uuid, String outputFileLocation, int expirationPeriodInDays) throws EmailException {
+    public void sendCompletedJobEmail(String to, String uuid, String statusPageLink, int expirationPeriodInDays) throws EmailException {
         String subject = COMPLETED_JOB_EMAIL_SUBJECT + uuid;
         String expirationPeriod = String.format("%d days", expirationPeriodInDays);
-        String textBody = templateManager.getCompletedEmailContent(uuid, expirationPeriod, outputFileLocation);
+        String textBody = templateManager.getCompletedEmailContent(uuid, expirationPeriod, statusPageLink);
         String from = JOB_EMAIL_FROM_ADDRESS;
 
         sendEmail(to, from, subject, null, textBody);

--- a/wps-common/src/main/java/au/org/aodn/aws/util/EmailTemplateManager.java
+++ b/wps-common/src/main/java/au/org/aodn/aws/util/EmailTemplateManager.java
@@ -55,12 +55,12 @@ public class EmailTemplateManager {
         }
     }
 
-    public String getCompletedEmailContent(String uuid, String expirationPeriod, String outputFileLocation) throws EmailException {
+    public String getCompletedEmailContent(String uuid, String expirationPeriod, String statusUrl) throws EmailException {
         try {
             Template t = velocityEngine.getTemplate(EmailService.getCompletedJobEmailTemplate());
             VelocityContext context = new VelocityContext();
             context.put(UUID, uuid);
-            context.put(JOB_REPORT_URL, outputFileLocation);
+            context.put(JOB_REPORT_URL, statusUrl);
             context.put(EXPIRATION_PERIOD, expirationPeriod);
             context.put(CONTACT_EMAIL, JOB_EMAIL_CONTACT_ADDRESS);
 


### PR DESCRIPTION
Resolve https://github.com/aodn/aodn-portal/issues/2585 by changing email to contain a link to the the status page for the job rather than the raw output file link.