### PR TITLE
Remove custom name from ComputeEnvironment - it stops it being able t…

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -427,7 +427,6 @@ Resources:
     DeletionPolicy: Delete
     Properties:
       Type: MANAGED
-      ComputeEnvironmentName: !Sub 'JavaDuckSpotComputeEnvironment-v1-${AWS::StackName}'
       ComputeResources:
         Type: SPOT
         MinvCpus: 0


### PR DESCRIPTION
…o be updated if required. IE: update_stack operation fails.