### PR TITLE
Parameter validation for aws-wps requests

### DIFF
--- a/dev.properties
+++ b/dev.properties
@@ -1,7 +1,4 @@
 dockerImage=615645230945.dkr.ecr.ap-southeast-2.amazonaws.com/javaduck:latest
 geoserver=http://geoserver-123.aodn.org.au/geoserver/imos/ows
-s3LambdaCodeFilename=request-handler.zip
-s3LambdaCodeURL=https://s3-ap-southeast-2.amazonaws.com/wps-lambda/request-handler-0.01-lambda-package.zip
 templatesURL=https://raw.githubusercontent.com/aodn/aws-wps/master/wps-common/src/main/resources/config/templates.xml
-administratorEmail=developers@emii.org.au
 geonetworkCatalogueURL=http://catalogue-sandbox.aodn.org.au/geonetwork

--- a/dev.properties
+++ b/dev.properties
@@ -4,3 +4,4 @@ s3LambdaCodeFilename=request-handler.zip
 s3LambdaCodeURL=https://s3-ap-southeast-2.amazonaws.com/wps-lambda/request-handler-0.01-lambda-package.zip
 templatesURL=https://raw.githubusercontent.com/aodn/aws-wps/master/wps-common/src/main/resources/config/templates.xml
 administratorEmail=developers@emii.org.au
+geonetworkCatalogueURL=http://catalogue-sandbox.aodn.org.au/geonetwork

--- a/request-handler/src/main/java/au/org/aodn/aws/wps/lambda/WpsLambdaRequestHandler.java
+++ b/request-handler/src/main/java/au/org/aodn/aws/wps/lambda/WpsLambdaRequestHandler.java
@@ -6,6 +6,7 @@ import au.org.aodn.aws.wps.AwsApiResponse;
 import au.org.aodn.aws.wps.AwsApiResponse.ResponseBuilder;
 import au.org.aodn.aws.wps.RequestParser;
 import au.org.aodn.aws.wps.RequestParserFactory;
+import au.org.aodn.aws.wps.exception.ValidationException;
 import au.org.aodn.aws.util.JobFileUtil;
 import au.org.aodn.aws.wps.operation.Operation;
 import com.amazonaws.services.lambda.runtime.Context;
@@ -78,6 +79,11 @@ public class WpsLambdaRequestHandler implements RequestHandler<AwsApiRequest, Aw
             responseBuilder.statusCode(500);
             String exceptionReportString = JobFileUtil.getExceptionReportString(oe.getExceptionText(),
                 oe.getExceptionCode(), oe.getLocator());
+            responseBuilder.body(exceptionReportString);
+        } catch (ValidationException ve) {
+            LOGGER.error("Error in request parameters " + ve.getMessage(), ve);
+            responseBuilder.statusCode(500);
+            String exceptionReportString = JobFileUtil.getExceptionReportString(ve.getMessage(), "ValidationError");
             responseBuilder.body(exceptionReportString);
         } catch (Exception e) {
             LOGGER.error("Exception : " + e.getMessage(), e);

--- a/request-handler/src/main/java/au/org/aodn/aws/wps/operation/ExecuteOperation.java
+++ b/request-handler/src/main/java/au/org/aodn/aws/wps/operation/ExecuteOperation.java
@@ -3,6 +3,7 @@ package au.org.aodn.aws.wps.operation;
 import au.org.aodn.aws.util.EmailService;
 import au.org.aodn.aws.util.JobFileUtil;
 import au.org.aodn.aws.wps.request.ExecuteRequestHelper;
+import au.org.aodn.aws.wps.exception.ValidationException;
 import au.org.aodn.aws.wps.status.*;
 import com.amazonaws.services.batch.AWSBatch;
 import com.amazonaws.services.batch.AWSBatchClientBuilder;
@@ -30,7 +31,7 @@ public class ExecuteOperation implements Operation {
 
 
     @Override
-    public String execute() {
+    public String execute() throws ValidationException {
 
         //  Config items:
         //      queue names
@@ -54,6 +55,7 @@ public class ExecuteOperation implements Operation {
         LOGGER.info("awsRegion: " + awsRegion);
 
         ExecuteRequestHelper helper = new ExecuteRequestHelper(executeRequest);
+        helper.validateInputs();
         String email = helper.getEmail();
 
         String processIdentifier = executeRequest.getIdentifier().getValue();  // code spaces not supported for the moment

--- a/request-handler/src/main/java/au/org/aodn/aws/wps/operation/Operation.java
+++ b/request-handler/src/main/java/au/org/aodn/aws/wps/operation/Operation.java
@@ -1,7 +1,8 @@
 package au.org.aodn.aws.wps.operation;
 
 import au.org.aodn.aws.exception.OGCException;
+import au.org.aodn.aws.wps.exception.ValidationException;
 
 public interface Operation {
-    String execute() throws OGCException;
+    String execute() throws OGCException, ValidationException;
 }

--- a/wps-common/src/main/java/au/org/aodn/aws/wps/exception/ValidationException.java
+++ b/wps-common/src/main/java/au/org/aodn/aws/wps/exception/ValidationException.java
@@ -1,0 +1,24 @@
+package au.org.aodn.aws.wps.exception;
+
+public class ValidationException extends Exception {
+
+    public ValidationException()
+    {
+        super();
+    }
+
+    public ValidationException(String message)
+    {
+        super(message);
+    }
+
+    public ValidationException(String message, Throwable ex)
+    {
+        super(message, ex);
+    }
+
+    public ValidationException(Throwable ex)
+    {
+        super(ex);
+    }
+}

--- a/wps-common/src/main/java/au/org/aodn/aws/wps/request/ExecuteRequestHelper.java
+++ b/wps-common/src/main/java/au/org/aodn/aws/wps/request/ExecuteRequestHelper.java
@@ -5,6 +5,8 @@ import net.opengis.wps.v_1_0_0.Execute;
 import net.opengis.wps.v_1_0_0.InputType;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import au.org.aodn.aws.wps.exception.ValidationException;
 
@@ -48,17 +50,16 @@ public class ExecuteRequestHelper {
         if (subset == null) {
             throw new ValidationException("Request must have a subset");
         } else {
-            String[] subsetFields = subset.split(";", -1);
-            String[] requiredFields = {"LATITUDE", "LONGITUDE"};
+            int latLonCount = 0;
+            Pattern latLonPattern = Pattern.compile("([+-]?\\d+\\.?\\d+)\\s*,\\s*([+-]?\\d+\\.?\\d+)");
+            Matcher matcher = latLonPattern.matcher(subset);
 
-            if (subsetFields.length != requiredFields.length) {
-                throw new ValidationException("Subset is incorrectly formatted");
-            } else {
-                for (int i = 0; i < subsetFields.length; i++) {
-                    if (!subsetFields[i].startsWith(requiredFields[i])) {
-                        throw new ValidationException("Subset is missing required field: " + requiredFields[i]);
-                    }
-                }
+            while (matcher.find()) {
+                latLonCount++;
+            }
+
+            if (latLonCount != 2) {
+                throw new ValidationException(String.format("Invalid latitude/longitude format for subset: %s", subset));
             }
         }
 

--- a/wps-common/src/main/java/au/org/aodn/aws/wps/request/ExecuteRequestHelper.java
+++ b/wps-common/src/main/java/au/org/aodn/aws/wps/request/ExecuteRequestHelper.java
@@ -6,6 +6,8 @@ import net.opengis.wps.v_1_0_0.InputType;
 
 import java.util.List;
 
+import au.org.aodn.aws.wps.exception.ValidationException;
+
 public class ExecuteRequestHelper {
     private final Execute request;
 
@@ -32,6 +34,37 @@ public class ExecuteRequestHelper {
         }
 
         return false;
+    }
+
+    public void validateInputs() throws ValidationException {
+        String layerName = getLiteralInputValue("layer");
+        String subset = getLiteralInputValue("subset");
+        String email = getEmail();
+
+        if (layerName == null) {
+            throw new ValidationException("Request must have a layer name");
+        }
+
+        if (subset == null) {
+            throw new ValidationException("Request must have a subset");
+        } else {
+            String[] subsetFields = subset.split(";", -1);
+            String[] requiredFields = {"LATITUDE", "LONGITUDE"};
+
+            if (subsetFields.length != requiredFields.length) {
+                throw new ValidationException("Subset is incorrectly formatted");
+            } else {
+                for (int i = 0; i < subsetFields.length; i++) {
+                    if (!subsetFields[i].startsWith(requiredFields[i])) {
+                        throw new ValidationException("Subset is missing required field: " + requiredFields[i]);
+                    }
+                }
+            }
+        }
+
+        if (email == null) {
+            throw new ValidationException("Request must have a callback email");
+        }
     }
 
     public String getRequestedMimeType(String identifier) {


### PR DESCRIPTION
Requests are validated as follows:

Subset, layer and callback email are required parameters.
Subset must have a latitude, longitude and temporal section.
If these conditions are not met, the request aborts before going to batch.

Add geonetwork URL as sandbox for development mode.