### PR TITLE
Set bucketName parameter to be given any bucket name.

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -28,12 +28,6 @@ Parameters:
   bucketName:
     Type: String
     Default: aws-wps-dev
-    AllowedValues:
-      - aws-wps-production
-      - aws-wps-systest
-      - aws-wps-sandbox
-      - aws-wps-edge
-      - aws-wps-dev
   awsRegionSes:
     Type: String
     Default: us-east-1


### PR DESCRIPTION
Advantages of this are:
1. when we add a new stack we only have to add the new bucket to one place (the deployment job)
1. when doing development work on aws-wps we can easily set our own persistent bucket rather than being forced to use an ephemeral bucket.

@jonescc @ccmoloney 