### PR TITLE
Add support for a test transaction queue + compute environment

### DIFF
--- a/request-handler/pom.xml
+++ b/request-handler/pom.xml
@@ -103,11 +103,6 @@
             <version>2.8.2</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.8.2</version>
-        </dependency>
-        <dependency>
             <groupId>au.org.emii</groupId>
             <artifactId>wps-common</artifactId>
             <version>4.37.0</version>

--- a/request-handler/src/main/java/au/org/aodn/aws/wps/operation/JobMapper.java
+++ b/request-handler/src/main/java/au/org/aodn/aws/wps/operation/JobMapper.java
@@ -32,8 +32,8 @@ public class JobMapper {
         }
 
         //  Set the job queue name
-        //  If the job contains an indicator that it is a test transaction (a specific process identifier) return the test queue
         if(processIdentifier.equalsIgnoreCase(WpsConfig.GOGODUCK_PROCESS_IDENTIFIER)) {
+            //  If the job is a test transaction return the test queue name
             if(isTestTransaction(executeRequest)) {
                 settings.setJobQueueName(WpsConfig.getProperty(AWS_BATCH_TEST_QUEUE_NAME_CONFIG_KEY));
             } else {

--- a/request-handler/src/main/java/au/org/aodn/aws/wps/operation/JobMapper.java
+++ b/request-handler/src/main/java/au/org/aodn/aws/wps/operation/JobMapper.java
@@ -1,29 +1,85 @@
 package au.org.aodn.aws.wps.operation;
 
+import au.org.aodn.aws.exception.OGCException;
 import au.org.aodn.aws.wps.status.WpsConfig;
+import net.opengis.wps.v_1_0_0.DataInputsType;
+import net.opengis.wps.v_1_0_0.Execute;
+import net.opengis.wps.v_1_0_0.InputType;
+import java.util.List;
 
 import static au.org.aodn.aws.wps.status.WpsConfig.AWS_BATCH_JOB_DEFINITION_NAME_CONFIG_KEY;
+import static au.org.aodn.aws.wps.status.WpsConfig.AWS_BATCH_JOB_QUEUE_NAME_CONFIG_KEY;
+import static au.org.aodn.aws.wps.status.WpsConfig.AWS_BATCH_TEST_QUEUE_NAME_CONFIG_KEY;
 
 public class JobMapper {
-    private String processIdentifier;
 
-    public JobMapper(String processIdentifier) {
-        this.processIdentifier = processIdentifier;
-    }
+    public static String TEST_TRANSACTION_INPUT_IDENTIFIER = "TestMode";
 
-    public String getJobDefinitionName() {
-        if(processIdentifier.equalsIgnoreCase("gs:gogoduck")) {
-            return WpsConfig.getProperty(AWS_BATCH_JOB_DEFINITION_NAME_CONFIG_KEY);
-        } else {
-            return null;
+    public static JobSettings getJobSettings(Execute executeRequest) throws OGCException {
+
+        //  Do some validation on the jobDefinitionName
+        if(executeRequest.getIdentifier() == null || executeRequest.getIdentifier().getValue() == null) {
+            //  Throw an error
+            throw new OGCException("ProcessError", "No process identifier was supplied.");
         }
+        String processIdentifier = executeRequest.getIdentifier().getValue();
+        JobSettings settings = new JobSettings();
+
+        //  TODO:  Can map to different queues + job definitions here based on process identifiers
+        //  Set job definition name
+        if(processIdentifier.equalsIgnoreCase("gs:gogoduck")) {
+            settings.setJobDefinitionName(WpsConfig.getProperty(AWS_BATCH_JOB_DEFINITION_NAME_CONFIG_KEY));
+        }
+
+        //  Set the job queue name
+        //  If the job contains an indicator that it is a test transaction (a specific process identifier) return the test queue
+        if(processIdentifier.equalsIgnoreCase("gs:gogoduck")) {
+            if(isTestTransaction(executeRequest)) {
+                settings.setJobQueueName(WpsConfig.getProperty(AWS_BATCH_TEST_QUEUE_NAME_CONFIG_KEY));
+            } else {
+                settings.setJobQueueName(WpsConfig.getProperty(AWS_BATCH_JOB_QUEUE_NAME_CONFIG_KEY));
+            }
+        }
+
+        settings.setProcessIdentifier(processIdentifier);
+
+        return settings;
     }
 
-    public String getProcessIdentifier() {
-        return processIdentifier;
-    }
+    /**
+     * Check to see if this is a test transaction or not.  A test transaction is indicated by the presence of an Input in
+     * the DataInputs section of the Execute request whose name is TestMode and whose literal value is 'true'.
+     * eg:
+     *  <wps:Input>
+     *      <ows:Identifier>TestMode</ows:Identifier>
+     *      <wps:Data>
+     *          <wps:LiteralData>true</wps:LiteralData>
+     *      </wps:Data>
+     *  </wps:Input>
+     *
+     * @param executeRequest
+     * @return
+     */
+    private static boolean isTestTransaction(Execute executeRequest) {
 
-    public void setProcessIdentifier(String processIdentifier) {
-        this.processIdentifier = processIdentifier;
+        if(executeRequest.getDataInputs() != null && executeRequest.getDataInputs().getInput() != null && executeRequest.getDataInputs().getInput().size() > 0)
+        {
+            DataInputsType dataInputs = executeRequest.getDataInputs();
+            List<InputType> inputs = dataInputs.getInput();
+
+            for(InputType input : inputs) {
+                if(input.getIdentifier() != null) {
+                    String inputName = input.getIdentifier().getValue();
+                    if(inputName.equalsIgnoreCase(TEST_TRANSACTION_INPUT_IDENTIFIER)) {
+                        if(input.getData() != null && input.getData().getLiteralData() != null) {
+                            String value = input.getData().getLiteralData().getValue();
+                            return Boolean.parseBoolean(value);
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/request-handler/src/main/java/au/org/aodn/aws/wps/operation/JobMapper.java
+++ b/request-handler/src/main/java/au/org/aodn/aws/wps/operation/JobMapper.java
@@ -27,13 +27,13 @@ public class JobMapper {
 
         //  TODO:  Can map to different queues + job definitions here based on process identifiers
         //  Set job definition name
-        if(processIdentifier.equalsIgnoreCase("gs:gogoduck")) {
+        if(processIdentifier.equalsIgnoreCase(WpsConfig.GOGODUCK_PROCESS_IDENTIFIER)) {
             settings.setJobDefinitionName(WpsConfig.getProperty(AWS_BATCH_JOB_DEFINITION_NAME_CONFIG_KEY));
         }
 
         //  Set the job queue name
         //  If the job contains an indicator that it is a test transaction (a specific process identifier) return the test queue
-        if(processIdentifier.equalsIgnoreCase("gs:gogoduck")) {
+        if(processIdentifier.equalsIgnoreCase(WpsConfig.GOGODUCK_PROCESS_IDENTIFIER)) {
             if(isTestTransaction(executeRequest)) {
                 settings.setJobQueueName(WpsConfig.getProperty(AWS_BATCH_TEST_QUEUE_NAME_CONFIG_KEY));
             } else {

--- a/request-handler/src/main/java/au/org/aodn/aws/wps/operation/JobSettings.java
+++ b/request-handler/src/main/java/au/org/aodn/aws/wps/operation/JobSettings.java
@@ -1,0 +1,32 @@
+package au.org.aodn.aws.wps.operation;
+
+public class JobSettings {
+
+    private String jobQueueName;
+    private String processIdentifier;
+    private String jobDefinitionName;
+
+    public String getJobQueueName() {
+        return jobQueueName;
+    }
+
+    public void setJobQueueName(String jobQueueName) {
+        this.jobQueueName = jobQueueName;
+    }
+
+    public String getProcessIdentifier() {
+        return processIdentifier;
+    }
+
+    public void setProcessIdentifier(String jobIdentifier) {
+        this.processIdentifier = jobIdentifier;
+    }
+
+    public String getJobDefinitionName() {
+        return jobDefinitionName;
+    }
+
+    public void setJobDefinitionName(String jobDefinitionName) {
+        this.jobDefinitionName = jobDefinitionName;
+    }
+}

--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -398,6 +398,8 @@ Resources:
           - Order: 1
             ComputeEnvironment: !Ref TestComputeEnvironment
   JobComputeEnvironment:
+    Metadata:
+      Comment: Please apply any changes made to this ComputeEnvironment to TestComputeEnvironment also!!!!!
     Type: AWS::Batch::ComputeEnvironment
     DeletionPolicy: Delete
     Properties:
@@ -423,6 +425,8 @@ Resources:
         BidPercentage: 100
       ServiceRole: !Ref BatchServiceRole
   TestComputeEnvironment:
+      Metadata:
+        Comment: Please keep in sync with JobComputeEnvironment!!!!!
       Type: AWS::Batch::ComputeEnvironment
       DeletionPolicy: Delete
       Properties:

--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -384,12 +384,20 @@ Resources:
   JobQueue:
     Type: AWS::Batch::JobQueue
     Properties:
-      JobQueueName: !Sub 'JavaDuckQueue1-${AWS::StackName}'
+      JobQueueName: !Sub 'JavaDuckExecuteQueue-${AWS::StackName}'
       Priority: 2
       ComputeEnvironmentOrder:
         - Order: 1
-          ComputeEnvironment: !Ref ComputeEnvironment
-  ComputeEnvironment:
+          ComputeEnvironment: !Ref JobComputeEnvironment
+  TestQueue:
+      Type: AWS::Batch::JobQueue
+      Properties:
+        JobQueueName: !Sub 'JavaDuckTestQueue-${AWS::StackName}'
+        Priority: 2
+        ComputeEnvironmentOrder:
+          - Order: 1
+            ComputeEnvironment: !Ref TestComputeEnvironment
+  JobComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     DeletionPolicy: Delete
     Properties:
@@ -414,6 +422,31 @@ Resources:
         SpotIamFleetRole: !Ref SpotIamFleetRole
         BidPercentage: 100
       ServiceRole: !Ref BatchServiceRole
+  TestComputeEnvironment:
+      Type: AWS::Batch::ComputeEnvironment
+      DeletionPolicy: Delete
+      Properties:
+        Type: MANAGED
+        ComputeResources:
+          Type: SPOT
+          MinvCpus: 0
+          DesiredvCpus: 0
+          MaxvCpus: !Ref maxVCPUs
+          InstanceTypes:
+            - c3.large
+            - c4.large
+            - m3.large
+            - m4.large
+            - r4.large
+            - r3.large
+          ImageId: !If [UseCustomAmi, !FindInMap [AccountConstants, !Ref 'AWS::AccountId', CustomAmiId], !Ref 'AWS::NoValue']
+          Subnets: !FindInMap [!Ref 'AWS::AccountId', !Ref 'AWS::Region', subnets]
+          SecurityGroupIds:
+            - !Ref ComputeEnvironmentInstanceSecurityGroup
+          InstanceRole: !Ref IamInstanceProfile
+          SpotIamFleetRole: !Ref SpotIamFleetRole
+          BidPercentage: 100
+        ServiceRole: !Ref BatchServiceRole
   ComputeEnvironmentInstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -566,6 +599,7 @@ Resources:
         Variables:
           AWS_BATCH_JOB_NAME: javaduck
           AWS_BATCH_JOB_QUEUE_NAME: !Ref JobQueue
+          AWS_BATCH_TEST_QUEUE_NAME: !Ref TestQueue
           AWS_BATCH_JOB_DEFINITION_NAME: !Select [1, !Split ['/', !Ref JobDefinition]]
           ADMINISTRATOR_EMAIL: !Ref administratorEmail
           OUTPUT_S3_BUCKET: !If [CreateEphemeralBucket, !Ref EphemeralS3Bucket, !Ref bucketName]
@@ -816,9 +850,13 @@ Outputs:
       - CreateWpsApiGatewayDomainName
       - !Sub ['https://${WpsRoute53RecordSet}/${requestHandlerApiPath}/${jobStatusApiPath}',{requestHandlerApiPath: !FindInMap [Constants, ConstantMap, requestHandlerApiPath], jobStatusApiPath: !FindInMap [Constants, ConstantMap, jobStatusApiPath]}]
       - !Sub ['https://${WPSRestApi}.execute-api.${AWS::Region}.amazonaws.com/${wpsApiStage}/${requestHandlerApiPath}/${jobStatusApiPath}',{wpsApiStage: !FindInMap [Constants, ConstantMap, wpsApiStage], requestHandlerApiPath: !FindInMap [Constants, ConstantMap, requestHandlerApiPath], jobStatusApiPath: !FindInMap [Constants, ConstantMap, jobStatusApiPath]}]
-  ComputeEnvironmentArn:
-    Value: !Ref ComputeEnvironment
+  JobComputeEnvironmentArn:
+    Value: !Ref JobComputeEnvironment
+  TestComputeEnvironmentArn:
+    Value: !Ref TestComputeEnvironment
   JobQueueArn:
     Value: !Ref JobQueue
+  TestQueueArn:
+    Value: !Ref TestQueue
   JobDefinitionArn:
     Value: !Ref JobDefinition

--- a/wps-common/src/main/java/au/org/aodn/aws/wps/status/WpsConfig.java
+++ b/wps-common/src/main/java/au/org/aodn/aws/wps/status/WpsConfig.java
@@ -17,6 +17,7 @@ public class WpsConfig {
     //  Configuration key names
     public static final String AWS_BATCH_JOB_NAME_CONFIG_KEY = "AWS_BATCH_JOB_NAME";
     public static final String AWS_BATCH_JOB_QUEUE_NAME_CONFIG_KEY = "AWS_BATCH_JOB_QUEUE_NAME";
+    public static final String AWS_BATCH_TEST_QUEUE_NAME_CONFIG_KEY = "AWS_BATCH_TEST_QUEUE_NAME";
     public static final String AWS_BATCH_JOB_DEFINITION_NAME_CONFIG_KEY = "AWS_BATCH_JOB_DEFINITION_NAME";
     public static final String AWS_BATCH_LOG_GROUP_NAME_CONFIG_KEY = "AWS_BATCH_LOG_GROUP_NAME";
 


### PR DESCRIPTION
To allow online resource monitor to regularly perform test transactions without affecting production users.  Test transaction triggered by adding a TestMode input to the execute request with a LiteralData value of 'true'.

Compute environment should be identical to the production environment so as to be a meaningful test.