### PR TITLE
Named parameters and stack tags

### DIFF
--- a/cloudformation.sh
+++ b/cloudformation.sh
@@ -25,7 +25,7 @@ function get_cache_bucket_for_account() {
 }
 
 function usage() {
-    echo "Usage: $0 [-p AWS_PROFILE] -s STACK_NAME -c CONFIG_FILE [-t TAGS]"
+    echo "Usage: $0 [-p AWS_PROFILE] -s STACK_NAME -c CONFIG_FILE [-t \"TAGS\"]"
     exit 1
 }
 
@@ -50,11 +50,6 @@ function main() {
       esac
     done
 
-    echo "AWS Profile     : $aws_profile"
-    echo "Stack name      : $stack_name"
-    echo "Config file     : $config_file"
-    echo "Tags            : $tags"
-
     # Check that we have all the mandatory parameters
     if [ -z "$stack_name" ] || [ -z "$config_file" ]; then
         usage
@@ -64,6 +59,11 @@ function main() {
     if [ -z "$aws_profile" ] ; then
         aws_profile="default"
     fi
+
+    echo "AWS Profile     : $aws_profile"
+    echo "Stack name      : $stack_name"
+    echo "Config file     : $config_file"
+    echo "Tags            : $tags"
 
     # Check that the config file exists
     if [ ! -e ${config_file} ]; then

--- a/cloudformation.sh
+++ b/cloudformation.sh
@@ -25,22 +25,57 @@ function get_cache_bucket_for_account() {
 }
 
 function usage() {
-    echo "Usage: $0 [AWS_PROFILE] STACK_NAME PROPERTIES_FILE"
+    echo "Usage: $0 [-p AWS_PROFILE] -s STACK_NAME -c CONFIG_FILE [-t TAGS]"
     exit 1
 }
 
 function main() {
-    # parameter parsing
-    [[ $# -lt 2 || $# -gt 3 ]] && usage
-    local aws_profile
-    if [[ $# -eq 3 ]] ; then
-      aws_profile=$1; shift
-    else
-      aws_profile="default"
+    tags=""
+    config_file=""
+    stack_name=""
+    aws_profile=""
+
+    while getopts "p:s:c:t:" opt; do
+      case $opt in
+        p) aws_profile="$OPTARG"
+        ;;
+        s) stack_name="$OPTARG"
+        ;;
+        c) config_file="$OPTARG"
+        ;;
+        t) tags="$OPTARG"
+        ;;
+        \?) echo "Invalid option -$OPTARG" >&2
+        ;;
+      esac
+    done
+
+    echo "AWS Profile     : $aws_profile"
+    echo "Stack name      : $stack_name"
+    echo "Config file     : $config_file"
+    echo "Tags            : $tags"
+
+    # Check that we have all the mandatory parameters
+    if [ -z "$stack_name" ] || [ -z "$config_file" ]; then
+        usage
+        exit 2
     fi
-    local stack_name=$1; shift
-    local properties_file=$1; shift
-    [ ! -e ${properties_file} ] && usage
+
+    if [ -z "$aws_profile" ] ; then
+        aws_profile="default"
+    fi
+
+    # Check that the config file exists
+    if [ ! -e ${config_file} ]; then
+        echo "Config file $config_file does not exist."
+        usage
+        exit 2
+    fi
+
+    # Form the --tags clause if tags were passed
+    if [[ ! -z "$tags" ]] ; then
+        tags="--tags "$tags; shift
+    fi
 
     # resolve the appropriate cache bucket based on the account ID of the current credentials
     account_id=$(get_account_id $aws_profile)
@@ -56,7 +91,7 @@ function main() {
     trap "rm -f ${temporary_template}" EXIT
 
     aws --profile ${aws_profile} cloudformation package --template-file ./wps-cloudformation-template.yaml --s3-bucket ${cache_bucket} --s3-prefix lambda --output-template-file ${temporary_template}
-    aws --profile ${aws_profile} cloudformation deploy --template-file ${temporary_template} --stack-name ${stack_name} --parameter-overrides $(cat ${properties_file}) --capabilities CAPABILITY_IAM
+    aws --profile ${aws_profile} cloudformation deploy --template-file ${temporary_template} --stack-name ${stack_name} --parameter-overrides $(cat ${config_file}) --capabilities CAPABILITY_IAM ${tags}
 }
 
-main $@
+main "$@"


### PR DESCRIPTION
Make parameters 'named' and add support to pass stack tags (multiple if required) to the aws cloudformation deploy command.