### PR TITLE
changed gogoduck to GoGoDuck

### DIFF
--- a/requests/request.xml
+++ b/requests/request.xml
@@ -1,5 +1,5 @@
 <wps:Execute version="1.0.0" service="WPS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.opengis.net/wps/1.0.0" xmlns:wfs="http://www.opengis.net/wfs" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" xmlns:wcs="http://www.opengis.net/wcs/1.1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd">
-    <ows:Identifier>gs:gogoduck</ows:Identifier>
+    <ows:Identifier>gs:GoGoDuck</ows:Identifier>
     <wps:DataInputs>
         <wps:Input>
             <ows:Identifier>layer</ows:Identifier>


### PR DESCRIPTION
The example request was looking for gs:gogoduck but we deploy it as gs:GoGoDuck