### PR TITLE
Fix test for DescribeProcess when given unknown process

### DIFF
--- a/integration-testing/src/test/java/au/org/emii/wps/it/DescribeProcessIT.java
+++ b/integration-testing/src/test/java/au/org/emii/wps/it/DescribeProcessIT.java
@@ -38,7 +38,7 @@ public class DescribeProcessIT {
         .when()
             .get()
         .then()
-            .statusCode(500)
+            .statusCode(400)
             .contentType(ContentType.XML)
             .body(validateWith("/ows/1.1.0/owsAll.xsd"))
             .root("ExceptionReport.Exception")


### PR DESCRIPTION
Needs to match the new http status (400) as implemented in https://github.com/aodn/aws-wps/pull/277/