### PR TITLE
Jenkinsfile: set PATH to find docker ECR credentials helper script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,8 +55,10 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME == 'master') {
                         docker.build("javaduck:${env.BUILD_ID}", "aggregation-worker/")
-                        docker.withRegistry(env.ECR_REGISTRY_URL) {
-                            docker.image("javaduck:${env.BUILD_ID}").push('latest')
+                        withEnv(['PATH+EXTRA=/var/lib/jenkins/bin']) {
+                            docker.withRegistry(env.ECR_REGISTRY_URL) {
+                                docker.image("javaduck:${env.BUILD_ID}").push("latest")
+                            }
                         }
                     } else {
                         docker.build("javaduck-${env.BRANCH_NAME}:${env.BUILD_ID}", "aggregation-worker/")


### PR DESCRIPTION
Note: don't merge until associated Jenkins config management PR is merged.

This allows the `docker push` command to find the `docker-credential-ecr-login` binary in the Jenkins $HOME/bin directory.