### PR TITLE
Don't specify a bucketname for dev environments (to allow inclusion i…

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -102,7 +102,6 @@ Resources:
     Condition: CreateEphemeralBucket
     DeletionPolicy: Delete
     Properties:
-      BucketName: !Join ['-', [!Ref bucketName, !Ref 'AWS::StackName']]
       LifecycleConfiguration:
         Rules:
           - Id: JobExpirationInDays


### PR DESCRIPTION
…n full dev stacks)

When deploying as a nested stack, deployment fails due to the child stack name containing upper case characters (which are invalid for S3). Omitting the BucketName will cause it to autogenerate a suitable name.

This is only applicable for dev stacks, and has no bearing on production.