### PR TITLE
Add condition to S3BucketPolicy so that it doesn't try to add a polic…

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -110,7 +110,7 @@ Resources:
     Type: AWS::S3::BucketPolicy
     Condition: CreateEphemeralBucket
     Properties:
-      Bucket: !If [CreateEphemeralBucket, !Ref EphemeralS3Bucket, !Ref bucketName]
+      Bucket: !Ref EphemeralS3Bucket
       PolicyDocument:
         Statement:
           -
@@ -118,9 +118,8 @@ Resources:
               - s3:GetObject
             Effect: Allow
             Resource: !Sub
-              - 'arn:aws:s3:::${BucketName}/${S3Prefix}*'
-              - BucketName: !If [CreateEphemeralBucket, !Ref EphemeralS3Bucket, !Ref bucketName]
-                S3Prefix: !FindInMap [Constants, ConstantMap, S3JobKeyPrefix]
+              - 'arn:aws:s3:::${EphemeralS3Bucket}/${S3Prefix}*'
+              - S3Prefix: !FindInMap [Constants, ConstantMap, S3JobKeyPrefix]
             Principal: '*'
   EmptyBucketLambdaFunction:
     Type: AWS::Lambda::Function

--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -108,6 +108,7 @@ Resources:
           Value: true
   S3BucketPolicy:
     Type: AWS::S3::BucketPolicy
+    Condition: CreateEphemeralBucket
     Properties:
       Bucket: !If [CreateEphemeralBucket, !Ref EphemeralS3Bucket, !Ref bucketName]
       PolicyDocument:


### PR DESCRIPTION
…y to external static buckets

If a bucket is externally defined, then it should have appropriate policies in place already. It regularly causes issues having a dynamic stack managing resources on external static resources!