### PR TITLE
Use newly build AMIs with gp3 storage attached

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -48,10 +48,10 @@ Parameters:
       - ap-southeast-2
   CustomAmiId:
     Type: String
-    Default: ami-bd06f3df
+    Default: ami-00e94e589a51ccdb0
   TestCustomAmiId:
     Type: String
-    Default: ami-0c7f195015aedf700
+    Default: ami-08503f06b09dbfc32
   AllowEphemeralBuckets:
     Type: String
     AllowedValues: [ true, false ]


### PR DESCRIPTION
For https://github.com/aodn/backlog/issues/2558
The new AMIs can be seen in the AMI section of the AWS console in production-admin account