### PR TITLE
Point to https version of our content repository

### DIFF
--- a/aggregation-worker/pom.xml
+++ b/aggregation-worker/pom.xml
@@ -154,7 +154,7 @@
     <repositories>
         <repository>
             <id>aodn</id>
-            <url>http://content.aodn.org.au/repo/maven/</url>
+            <url>https://s3.ap-southeast-2.amazonaws.com/content.aodn.org.au/repo/maven/</url>
         </repository>
         <repository>
             <id>unidata-all</id>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <repositories>
         <repository>
             <id>aodn</id>
-            <url>http://content.aodn.org.au/repo/maven/</url>
+            <url>https://s3.ap-southeast-2.amazonaws.com/content.aodn.org.au/repo/maven/</url>
         </repository>
         <repository>
             <id>unidata-releases</id>


### PR DESCRIPTION
I did have a brief look at what it would take to get https://content.aodn.org.au working instead, but it would require us to set up a new cloudfront distribution and point at it instead of the bucket, which I think would be overkill for fixing a small issue like this (especially when we do already have an https endpoint, even if the url is a bit messy)

Fixes https://github.com/aodn/issues/issues/1025

Successful build in Github Actions can be [seen here](https://github.com/aodn/aws-wps/actions/runs/969952704)