### PR TITLE
Add r5.large to potential instance type

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -424,6 +424,7 @@ Resources:
         InstanceTypes:
           - m3.large
           - m4.large
+          - r5.large
           - r4.large
           - r3.large
         ImageId: !If [UseCustomAmi, !Ref CustomAmiId, !Ref 'AWS::NoValue']
@@ -449,6 +450,7 @@ Resources:
           InstanceTypes:
             - m3.large
             - m4.large
+            - r5.large
             - r4.large
             - r3.large
           ImageId: !If [UseTestCustomAmi, !Ref TestCustomAmiId, !Ref 'AWS::NoValue']


### PR DESCRIPTION
r5 has improved specs over r4/r3, with no documented down-sides, so any application that works with r3/r4 should work with r5. Therefore we should have it as an option. 

(r5 didn't exist yet last time we edited the instance types)