### PR TITLE
Add some useful tags to wps spot instances

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -438,6 +438,7 @@ Resources:
         SpotIamFleetRole: !Ref SpotIamFleetRole
         BidPercentage: 100
       ServiceRole: !Ref BatchServiceRole
+      Tags: { "Name" : "AWS-WPS Worker", "AutoOff" : "False" }
   TestComputeEnvironment:
       Metadata:
         Comment: Please keep in sync with JobComputeEnvironment!!!!!
@@ -463,6 +464,7 @@ Resources:
           InstanceRole: !Ref IamInstanceProfile
           SpotIamFleetRole: !Ref SpotIamFleetRole
           BidPercentage: 100
+          Tags: { "Name" : "AWS-WPS Test Worker", "AutoOff" : "False" }
         ServiceRole: !Ref BatchServiceRole
   ComputeEnvironmentInstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
- "Name" so they're easier to spot in the EC2 instances console
- "AutoOff" so they don't get deleted at 7pm each day (if the parent stack itself have AutoOff=false then they'll still get deleted with it)

For https://github.com/aodn/backlog/issues/3268