### PR TITLE
Upgrade aggregation workers docker to ubuntu 20

### DIFF
--- a/aggregation-worker/Dockerfile
+++ b/aggregation-worker/Dockerfile
@@ -2,20 +2,15 @@
 # Dockerfile to build image for running gridded data aggregations
 #################################################################
 
-FROM ubuntu:xenial
+FROM ubuntu:20.04
 MAINTAINER AODN
 
 # Install Java.
 RUN \
   apt-get update && \
-  apt-get install -y openjdk-8-jdk && \
-  rm -rf /var/lib/apt/lists/*
-
-# Install netcdf library
-RUN \
-  apt-get update && \
-  apt-get install -y libnetcdf11 && \
-  rm -rf /var/lib/apt/lists/*
+  apt-get install -y openjdk-8-jdk \
+  libnetcdf15 \
+  && rm -rf /var/lib/apt/lists/*
 
 ADD target/lib /opt/aggregator/lib
 ADD target/*.jar /opt/aggregator/


### PR DESCRIPTION
Example job using the new docker image: https://xvrxr7mrkc.execute-api.ap-southeast-2.amazonaws.com/LATEST/wps/jobStatus?format=ADMIN&jobId=f836f1b1-7202-4319-8e32-1b9b89a6ee89

For https://github.com/aodn/backlog/issues/3708