### PR TITLE
Move non-test ec2 instance tag to correct location

### DIFF
--- a/wps-cloudformation-template.yaml
+++ b/wps-cloudformation-template.yaml
@@ -438,8 +438,8 @@ Resources:
         InstanceRole: !Ref IamInstanceProfile
         SpotIamFleetRole: !Ref SpotIamFleetRole
         BidPercentage: 100
+        Tags: { "Name" : "AWS-WPS Worker", "AutoOff" : "False" }
       ServiceRole: !Ref BatchServiceRole
-      Tags: { "Name" : "AWS-WPS Worker", "AutoOff" : "False" }
   TestComputeEnvironment:
       Metadata:
         Comment: Please keep in sync with JobComputeEnvironment!!!!!


### PR DESCRIPTION
Noticed while checking aws-wps costs for architecture review that tags were only working for test instances, and yep TestComputeEnvironment hsa the "Tags" key a level lower in the yaml.